### PR TITLE
feat: opción Recuérdame en login

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -15,7 +15,7 @@ const loginForm = async (req, res) => {
 // POST /login
 
 const login = async (req, res) => {
-  const { loginEmail, loginPassword } = req.body;
+  const { loginEmail, loginPassword, loginRemember } = req.body;
 
   try {
     const userLogin = await Usuario.findOne({
@@ -37,6 +37,12 @@ const login = async (req, res) => {
       email: userLogin.email,
       nivel_acceso: userLogin.nivel_acceso,
     };
+
+    if (loginRemember) {
+      req.session.cookie.maxAge = 30 * 24 * 60 * 60 * 1000;
+    } else {
+      req.session.cookie.maxAge = 60 * 60 * 1000;
+    }
 
     return res.status(200).json({ ok: true, redirect: "/dashboard" });
 

--- a/src/public/js/auth.js
+++ b/src/public/js/auth.js
@@ -2,7 +2,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const form = document.querySelector("#loginForm");
   const emailInput = document.querySelector("#loginEmail");
   const passwordInput = document.querySelector("#loginPassword");
+  const rememberInput = document.querySelector("#loginRemember");
   const loginMsg = document.querySelector("#loginMsg");
+
+  if (!form) return;
 
   const isValidEmail = (email) => {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -16,17 +19,31 @@ document.addEventListener("DOMContentLoaded", () => {
     input.classList.remove("error");
   };
 
-  form.addEventListener("submit", (e) => {
-    let errors = [];
+  const showMsg = (html, isError = true) => {
+    loginMsg.innerHTML = html;
+    loginMsg.style.display = "block";
+    loginMsg.classList.toggle("error-msg", isError);
+  };
+
+  const clearMsg = () => {
+    loginMsg.innerHTML = "";
+    loginMsg.style.display = "none";
+    loginMsg.classList.remove("error-msg");
+  };
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
 
     const email = emailInput.value.trim();
     const password = passwordInput.value.trim();
+    const remember = rememberInput ? rememberInput.checked : false;
 
-    // Reset visual
     clearError(emailInput);
     clearError(passwordInput);
+    clearMsg();
 
-    // Email
+    const errors = [];
+
     if (!email) {
       errors.push("El email és obligatori.");
       setError(emailInput);
@@ -35,7 +52,6 @@ document.addEventListener("DOMContentLoaded", () => {
       setError(emailInput);
     }
 
-    // Password
     if (!password) {
       errors.push("La contraseña és obligatòria.");
       setError(passwordInput);
@@ -45,17 +61,34 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (errors.length > 0) {
-      e.preventDefault();
-      loginMsg.innerHTML = errors.join("<br>");
-      loginMsg.style.display = "block";
-    } else {
-      loginMsg.innerHTML = "";
-      loginMsg.style.display = "none";
+      showMsg(errors.join("<br>"));
+      return;
+    }
+
+    try {
+      const res = await fetch("/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          loginEmail: email,
+          loginPassword: password,
+          loginRemember: remember,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (data.ok) {
+        window.location.href = data.redirect;
+      } else {
+        showMsg(data.error || "No s'ha pogut iniciar sessió.");
+      }
+    } catch (error) {
+      showMsg("No s'ha pogut iniciar sessió. Torna-ho a provar.");
     }
   });
 
-  // Limpia error al escribir
-  [emailInput, passwordInput].forEach(input => {
+  [emailInput, passwordInput].forEach((input) => {
     input.addEventListener("input", () => {
       clearError(input);
     });


### PR DESCRIPTION
closes #27
Añade la opción "Recuérdame" en el login.

Cambios realizados:
- envío de `loginRemember` desde el frontend
- extensión de `req.session.cookie.maxAge` a 30 días si está marcado
- mantener de 1 hora si no está marcado
- mejora de UX mostrando errores en `#loginMsg` en lugar de `alert`

