### PR TITLE
feat/mount-routes en routes/index

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,13 @@
 const router = require("express").Router();
+const { authPage } = require("../middlewares/auth.js")
+
 const authRoutes = require("./authRoutes");
 const alumnoRoutes = require("./alumnoRoutes");
 const cursoRoutes = require("./cursoRoutes");
 const profesorRoutes = require("./profesorRoutes");
 const ufRoutes = require("./ufRoutes");
 const usuarioRoutes = require("./usuarioRoutes");
+
 
 router.use("/", authRoutes);
 
@@ -13,7 +16,7 @@ router.use("/alumnos", alumnoRoutes);
 router.use("/cursos", cursoRoutes);
 router.use("/ufs", ufRoutes);
 router.use("/profesores", profesorRoutes);
-router.use("/usuarios", usuarioRoutes)
+router.use("/usuarios", usuarioRoutes);
 
 router.get("/", (req, res) => {
   if (req.session.usuario) return res.redirect("/dashboard");
@@ -21,8 +24,7 @@ router.get("/", (req, res) => {
 });
 
 // ruta dashboard
-router.get("/dashboard", (req, res) => {
-  if(!req.session.usuario) return res.redirect("/login");
+router.get("/dashboard", authPage, (req, res) => {
   res.render("dashboard", {usuario: req.session.usuario});
 });
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,12 +1,29 @@
 const router = require("express").Router();
 const authRoutes = require("./authRoutes");
+const alumnoRoutes = require("./alumnoRoutes");
+const cursoRoutes = require("./cursoRoutes");
+const profesorRoutes = require("./profesorRoutes");
+const ufRoutes = require("./ufRoutes");
+const usuarioRoutes = require("./usuarioRoutes");
 
 router.use("/", authRoutes);
+
+// Rutas con sus prefijos
+router.use("/alumnos", alumnoRoutes);
+router.use("/cursos", cursoRoutes);
+router.use("/ufs", ufRoutes);
+router.use("/profesores", profesorRoutes);
+router.use("/usuarios", usuarioRoutes)
 
 router.get("/", (req, res) => {
   if (req.session.usuario) return res.redirect("/dashboard");
   return res.redirect("/login");
 });
 
+// ruta dashboard
+router.get("/dashboard", (req, res) => {
+  if(!req.session.usuario) return res.redirect("/login");
+  res.render("dashboard", {usuario: req.session.usuario});
+});
 
 module.exports = router;


### PR DESCRIPTION
closes #37 
Se importaron los routers de alumnos, cursos, profesores, ufs y usuarios en el archivo routers/index.js
Para las rutas se consideraron los prefijos /alumnos, /cursos, /ufs, /profesores y /usuarios.
Se añadió la ruta para dashboard get("/dashboard").
