### PR TITLE
feat: CRUD UF - listar

### DIFF
--- a/src/controllers/ufController.js
+++ b/src/controllers/ufController.js
@@ -1,0 +1,23 @@
+const { Uf, Curso } = require("../models");
+
+// GET /ufs
+const getAll = async (req, res) => {
+    try {
+        const ufs = await Uf.findAll({
+            include: [{ model: Curso, attributes: ["id", "codigo", "nombre"] }],
+            order: [["codigo", "ASC"]],
+        });
+
+        res.render("ufs", {
+            titulo: "UFs",
+            usuario: req.session.usuario,
+            css: "ufs.css",
+            js: "ufs.js",
+            ufs,
+        });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+};
+
+module.exports = { getAll };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,7 +5,7 @@ const authRoutes = require("./authRoutes");
 const alumnoRoutes = require("./alumnoRoutes");
 const cursoRoutes = require("./cursoRoutes");
 // const profesorRoutes = require("./profesorRoutes");
-// const ufRoutes = require("./ufRoutes");
+const ufRoutes = require("./ufRoutes");
 // const usuarioRoutes = require("./usuarioRoutes");
 
 router.use("/", authRoutes);
@@ -13,7 +13,7 @@ router.use("/", authRoutes);
 // Rutas con sus prefijos
 router.use("/alumnos", alumnoRoutes);
 router.use("/cursos", cursoRoutes);
-// router.use("/ufs", ufRoutes);
+router.use("/ufs", ufRoutes);
 // router.use("/profesores", profesorRoutes);
 // router.use("/usuarios", usuarioRoutes);
 

--- a/src/routes/ufRoutes.js
+++ b/src/routes/ufRoutes.js
@@ -1,0 +1,12 @@
+const { Router } = require("express");
+const { authPage } = require("../middlewares/auth.js");
+const controller = require("../controllers/ufController");
+
+const router = Router();
+
+// Todas las rutas de UFs requieren autenticación
+router.use(authPage);
+
+router.get("/", controller.getAll);
+
+module.exports = router;

--- a/src/views/ufs.ejs
+++ b/src/views/ufs.ejs
@@ -1,0 +1,23 @@
+<h1>UFs</h1>
+
+<% if (ufs && ufs.length > 0) { %>
+  <ul>
+    <% ufs.forEach(uf => { %>
+      <li>
+        <strong><%= uf.codigo %></strong> — <%= uf.nombre %>
+        <% if (uf.horas) { %>(<%= uf.horas %>h)<% } %>
+        <% if (uf.Cursos && uf.Cursos.length > 0) { %>
+          <br>
+          <small>
+            Cursos:
+            <%= uf.Cursos.map(c => c.codigo + " " + c.nombre).join(", ") %>
+          </small>
+        <% } else { %>
+          <br><small>No associada a cap curs.</small>
+        <% } %>
+      </li>
+    <% }) %>
+  </ul>
+<% } else { %>
+  <p>No hi ha UFs registrades.</p>
+<% } %>


### PR DESCRIPTION
closes #41

Hola Alexandre, como no estás hoy y la issue #41 es de `back-express`, te he avanzado el CRUD UF para no bloquear al resto del equipo (cerrando esta issue puedo empezar la de `profesor-listar` que sigue huérfana).

**Lo que he hecho (rama `feat/uf-listar`):**

- `src/controllers/ufController.js` — `getAll` con `findAll` + `include: Curso` + `order: codigo ASC`.
- `src/routes/ufRoutes.js` — `router.use(authPage)` y `router.get("/", controller.getAll)`.
- `src/views/ufs.ejs` — listado con código, nombre, horas y cursos asociados.
- `src/routes/index.js` — descomentado el import y el `router.use("/ufs", ufRoutes)`.

**Patrón que he seguido** (por si miras luego):
- `usuario: req.session.usuario` en el render (el layout lo necesita para nav/topbar).
- `router.use(authPage)` al inicio del router (no repetirlo en cada `.get()`).
- Vista mínima, sin maquetar — eso va en otra issue de front-html.

Cuando vuelvas, si quieres ampliarla (detalle de UF, filtrar por curso, etc.) abrimos issue nueva y la coges tú.