### PR TITLE
feat: modales globales de success/error

### DIFF
--- a/src/public/css/modal.css
+++ b/src/public/css/modal.css
@@ -1,0 +1,80 @@
+.modal-overlay {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: none;
+  z-index: 1000;
+}
+
+.modal-overlay.is-open {
+  display: block;
+}
+
+.modal-card {
+  background-color: var(--color-fondo-pagina);
+  border: 1px solid var(--color-borde);
+  border-radius: var(--radio-pequeno);
+  padding: 0.75rem 2rem 0.75rem 0.9rem;
+  width: 280px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.15rem;
+  right: 0.4rem;
+  background: transparent;
+  border: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--color-texto-etiquetas);
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: var(--color-texto-principal);
+}
+
+.modal-icon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+
+.modal-title {
+  font-family: var(--fuente-titulos);
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 0 0 0.1rem 0;
+  color: var(--color-texto-principal);
+}
+
+.modal-message {
+  color: var(--color-texto-etiquetas);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.modal-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.modal-card.is-success .modal-icon {
+  color: #2ecc71;
+}
+
+.modal-card.is-error .modal-icon {
+  color: #e74c3c;
+}
+
+.modal-card.is-success .modal-title {
+  color: #27ae60;
+}
+
+.modal-card.is-error .modal-title {
+  color: #c0392b;
+}

--- a/src/public/js/auth.js
+++ b/src/public/js/auth.js
@@ -19,6 +19,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (!form) return;
 
+  if (new URLSearchParams(window.location.search).get("logout") === "1") {
+    window.showModal?.({
+      type: "success",
+      title: "Sessió tancada",
+      message: "Has tancat la sessió correctament.",
+    });
+    window.history.replaceState({}, "", window.location.pathname);
+  }
+
   const showMsg = (html, isError = true) => {
     loginMsg.innerHTML = html;
     loginMsg.style.display = "block";
@@ -79,12 +88,27 @@ document.addEventListener("DOMContentLoaded", () => {
       const data = await res.json();
 
       if (data.ok) {
-        window.location.href = data.redirect;
+        window.showModal?.({
+          type: "success",
+          title: "Sessió iniciada",
+          message: "Accedint al panell...",
+        });
+        setTimeout(() => { window.location.href = data.redirect; }, 2000);
+      } else if (res.status >= 500) {
+        window.showModal?.({
+          type: "error",
+          title: "Error del servidor",
+          message: "Torna-ho a provar d'aquí uns minuts.",
+        });
       } else {
         showMsg(data.error || "No s'ha pogut iniciar sessió.");
       }
     } catch (error) {
-      showMsg("No s'ha pogut iniciar sessió. Torna-ho a provar.");
+      window.showModal?.({
+        type: "error",
+        title: "Error de connexió",
+        message: "No s'ha pogut contactar amb el servidor.",
+      });
     }
   });
 
@@ -181,12 +205,27 @@ document.addEventListener("DOMContentLoaded", () => {
       const data = await response.json();
 
       if (data.ok) {
-        window.location.href = data.redirect;
+        window.showModal?.({
+          type: "success",
+          title: "Compte creat",
+          message: "Benvingut/da! Entrant al panell...",
+        });
+        setTimeout(() => { window.location.href = data.redirect; }, 2000);
+      } else if (response.status >= 500) {
+        window.showModal?.({
+          type: "error",
+          title: "Error del servidor",
+          message: "Torna-ho a provar d'aquí uns minuts.",
+        });
       } else {
         showMsg(data.error || "Error en el registre.");
       }
     } catch (error) {
-      showMsg("Error de connexió amb el servidor.");
+      window.showModal?.({
+        type: "error",
+        title: "Error de connexió",
+        message: "No s'ha pogut contactar amb el servidor.",
+      });
     }
   });
 

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -4,6 +4,6 @@ if (btnLogout) {
     btnLogout.addEventListener("click", async () => {
         const res = await fetch("/logout", { method: "POST" });
         const data = await res.json();
-        if (data.ok) window.location.href = data.redirect;
+        if (data.ok) window.location.href = data.redirect + "?logout=1";
     });
 }

--- a/src/public/js/modal.js
+++ b/src/public/js/modal.js
@@ -1,0 +1,48 @@
+(() => {
+  const overlay = document.getElementById("appModal");
+  if (!overlay) return;
+
+  const card = overlay.querySelector(".modal-card");
+  const iconEl = overlay.querySelector(".modal-icon");
+  const titleEl = overlay.querySelector(".modal-title");
+  const messageEl = overlay.querySelector(".modal-message");
+  const closeBtn = overlay.querySelector(".modal-close");
+
+  const ICONS = {
+    success: '<i class="fa-solid fa-circle-check"></i>',
+    error: '<i class="fa-solid fa-circle-xmark"></i>',
+  };
+
+  let autoCloseTimer = null;
+
+  const closeModal = () => {
+    overlay.classList.remove("is-open");
+    card.classList.remove("is-success", "is-error");
+    if (autoCloseTimer) {
+      clearTimeout(autoCloseTimer);
+      autoCloseTimer = null;
+    }
+  };
+
+  const openModal = ({ type = "success", title = "", message = "" } = {}) => {
+    card.classList.remove("is-success", "is-error");
+    card.classList.add(type === "error" ? "is-error" : "is-success");
+    iconEl.innerHTML = ICONS[type] || ICONS.success;
+    titleEl.textContent = title;
+    messageEl.textContent = message;
+    overlay.classList.add("is-open");
+    if (autoCloseTimer) clearTimeout(autoCloseTimer);
+    autoCloseTimer = setTimeout(closeModal, 3000);
+  };
+
+  closeBtn.addEventListener("click", closeModal);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) closeModal();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && overlay.classList.contains("is-open")) closeModal();
+  });
+
+  window.showModal = openModal;
+  window.closeModal = closeModal;
+})();

--- a/src/views/layout.ejs
+++ b/src/views/layout.ejs
@@ -6,10 +6,12 @@
     <title><%= titulo %> | CIFO La Violeta</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/css/modal.css">
     <% if (locals.css) { %>
         <link rel="stylesheet" href="/css/<%= css %>">
     <% } %>
     <script src="/js/main.js" defer></script>
+    <script src="/js/modal.js" defer></script>
     <% if (locals.js) { %>
         <script src="/js/<%= js %>" defer></script>
     <% } %>
@@ -73,6 +75,17 @@
             <main>
                 <%- body %>
             </main>
+        </div>
+    </div>
+
+    <div id="appModal" class="modal-overlay" role="dialog" aria-modal="true" aria-hidden="true">
+        <div class="modal-card">
+            <button type="button" class="modal-close" aria-label="Tancar">&times;</button>
+            <div class="modal-icon"></div>
+            <div class="modal-body">
+                <h2 class="modal-title"></h2>
+                <p class="modal-message"></p>
+            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Componente de modal reutilizable disponible en toda la app vía `window.showModal({ type, title, message })`.
- Dos variantes: `success` (verde) y `error` (rojo).
- Se muestra en la esquina superior derecha, tipo toast compacto.
- Cerrable con X, tecla Escape, y auto-cierre a 3s.
- Integrado en login (éxito, error de servidor, error de conexión), registro (éxito, error de servidor, error de conexión) y logout (éxito mediante flag `?logout=1` en la redirección).

## Test plan
- [x] Login correcto → modal "Sessió iniciada" durante 2s, redirige a /dashboard
- [x] Login con credenciales malas → mensaje inline (no modal)
- [ ] Registro correcto → modal "Compte creat" durante 2s, redirige a /dashboard
- [x] Logout → redirige a /login y aparece modal "Sessió tancada"
- [ ] Modal se cierra con X, con Escape, y solo a los 3s
- [ ] Refrescar página oculta el modal

closes #56