### PR TITLE
feat: gestionar errores 500 y 404 de recurso

### DIFF
--- a/src/controllers/alumnoController.js
+++ b/src/controllers/alumnoController.js
@@ -16,10 +16,9 @@ const getAll = async (req, res, next) => {
             alumnos
         });
     } catch (error) {
-            next(error);
-        }
-        //  res.status(500).json({ error: error.message });
-    };
+        next(error);
+    }
+};
 
 
 // GET /alumnos/nuevo
@@ -36,7 +35,7 @@ const createFormPrint = async (req, res) => {
 
 // POST /alumnos
 
-const newAlumno = async (req, res) => {
+const newAlumno = async (req, res, next) => {
     const { nombre, apellidos, dni, telefono, email, nivel_estudios, tipo, derechos_imagen, cesion_material, comentarios } = req.body;
 
     if (!nombre || !apellidos || !dni || !tipo) {
@@ -66,8 +65,7 @@ const newAlumno = async (req, res) => {
         return res.status(200).json({ ok: true, redirect: "/alumnos" });
 
     } catch (error) {
-        console.error(error);
-        res.status(500).json({ error: "Error del servidor." });
+        next(error);
     }
 };
 
@@ -81,10 +79,10 @@ const getById = async (req, res, next) => {
 
         if (!alumno) {
             req.session.flash = {
-            type: "error",
-            title: "No trobat",
-            message: "L'alumne no existeix.",
-                };
+                type: "error",
+                title: "No trobat",
+                message: "L'alumne no existeix.",
+            };
             return res.redirect("/alumnos");
         }
 
@@ -96,12 +94,12 @@ const getById = async (req, res, next) => {
             alumno
         });
     } catch (error) {
-        res.status(500).json({ error: error.message });
+        next(error);
     }
 };
 
 //DELETE/alumnos/:id
-const removeAlumno = async (req, res) => {
+const removeAlumno = async (req, res, next) => {
     try {
         const alumno = await Alumno.findByPk(req.params.id);
         if (!alumno) return res.status(404).json({
@@ -114,15 +112,11 @@ const removeAlumno = async (req, res) => {
             message: "Alumne eliminat correctament"
         });
     } catch (error) {
-        res.status(500).json({
-            ok: false,
-            message: "Error eliminant alumne"
-        });
+        next(error);
     }
-
 };
 
-const buscarAlumno = async (req, res) => {
+const buscarAlumno = async (req, res, next) => {
     const q = (req.query.q || "").trim();
     const tipo = (req.query.tipo || "").trim().toLowerCase();
 
@@ -157,8 +151,7 @@ const buscarAlumno = async (req, res) => {
         return res.json(alumnos);
 
     } catch (error) {
-        console.error("Error en buscarAlumno:", error);
-        return res.status(500).json({ error: "Error intern del servidor" });
+        next(error);
     }
 };
 
@@ -209,13 +202,11 @@ const updateAlumno = async (req, res, next) => {
             ultimo_id_modif: req.session.usuario.id,
         });
 
-        return res.json({ ok: true, redirect: `/alumnos/${req.params.id}` }); //comentamos luego
+        return res.json({ ok: true, redirect: `/alumnos/${req.params.id}` });
 
     } catch (error) {
-        console.error("Error al actualitzar alumne:", error);
-        res.status(500).json({ ok: false, mensaje: "Error del servidor." }); // comentamos al volver
+        next(error);
     }
-
 };
 
 module.exports = { getAll, createFormPrint, newAlumno, getById, removeAlumno, buscarAlumno, updateAlumno };

--- a/src/controllers/alumnoController.js
+++ b/src/controllers/alumnoController.js
@@ -3,7 +3,7 @@ const { Alumno, Curso } = require("../models");
 
 //GET /alumnos
 
-const getAll = async (req, res) => {
+const getAll = async (req, res, next) => {
     try {
         const alumnos = await Alumno.findAll({
             order: [["apellidos", "ASC"]],
@@ -16,9 +16,11 @@ const getAll = async (req, res) => {
             alumnos
         });
     } catch (error) {
-        res.status(500).json({ error: error.message });
-    }
-};
+            next(error);
+        }
+        //  res.status(500).json({ error: error.message });
+    };
+
 
 // GET /alumnos/nuevo
 
@@ -71,13 +73,18 @@ const newAlumno = async (req, res) => {
 
 // GET /alumnos/:id
 
-const getById = async (req, res) => {
+const getById = async (req, res, next) => {
     try {
         const alumno = await Alumno.findByPk(req.params.id, {
             include: [Curso],
         });
 
         if (!alumno) {
+            req.session.flash = {
+            type: "error",
+            title: "No trobat",
+            message: "L'alumne no existeix.",
+                };
             return res.redirect("/alumnos");
         }
 
@@ -157,7 +164,7 @@ const buscarAlumno = async (req, res) => {
 
 //PUT /alumnos/:id
 
-const updateAlumno = async (req, res) => {
+const updateAlumno = async (req, res, next) => {
     try {
         const alumno = await Alumno.findByPk(req.params.id);
         if (!alumno) {

--- a/src/controllers/cursoController.js
+++ b/src/controllers/cursoController.js
@@ -1,7 +1,7 @@
 const { Curso, Alumno, Uf, Profesor } = require("../models");
 
 /** GET /cursos */
-const getAll = async (req, res) => {
+const getAll = async (req, res, next) => {
     try {
         const cursos = await Curso.findAll();
         res.render("cursos", {
@@ -12,12 +12,13 @@ const getAll = async (req, res) => {
             cursos
         });
     } catch (error) {
-        res.status(500).json({ error: error.message });
+        /* res.status(500).json({ error: error.message });*/
+        next(error);
     }
 };
 
 /** GET /cursos/:id */
-const getById = async (req, res) => {
+const getById = async (req, resl, next) => {
     try {
         const curso = await Curso.findByPk(req.params.id, {
             include: [
@@ -26,8 +27,16 @@ const getById = async (req, res) => {
                 Alumno
             ],
         });
-        if (!curso)
-            return res.redirect("/cursos");
+        /* if (!curso)
+            return res.redirect("/cursos");*/
+        if (!curso) {
+            req.session.flash = {
+            type: "error",
+            title: "No trobat",
+            message: "El curs no existeix.",
+        };
+        return res.redirect("/cursos");
+    }
 
         res.render("curso-detalle", {
             titulo: "Busqueda de cursos por ID",
@@ -37,7 +46,8 @@ const getById = async (req, res) => {
         });
 
     } catch (error) {
-        res.status(500).json({ error: error.message });
+        /* res.status(500).json({ error: error.message }); */
+        next(error);
     }
 };
 

--- a/src/controllers/cursoController.js
+++ b/src/controllers/cursoController.js
@@ -31,18 +31,17 @@ const getById = async (req, res, next) => {
                 type: "error",
                 title: "No trobat",
                 message: "El curs no existeix.",
-                };
-                return res.redirect("/cursos");
-            }
+            };
+            return res.redirect("/cursos");
+        }
 
-            res.render("curso-detalle", {
-                titulo: "Busqueda de cursos por ID",
-                usuario: req.session.usuario,
-                css: "cursos.css",
-                curso
-                });
-
-        } catch (error) {
+        res.render("curso-detalle", {
+            titulo: "Busqueda de cursos por ID",
+            usuario: req.session.usuario,
+            css: "cursos.css",
+            curso
+        });
+    } catch (error) {
         next(error);
     }
 };
@@ -55,12 +54,12 @@ const renderNuevoCurso = (req, res) => {
         css: "cursos.css",
         js: "cursos.js",
         paginaActual: "cursos",
-        });
+    });
 };
 
 /** Crear curso (POST) */
 
-const crearCurso = async (req, res) => {
+const crearCurso = async (req, res, next) => {
     try {
         const { codigo, nombre, fecha_inicio, fecha_fin, requisitos } = req.body;
 
@@ -91,7 +90,6 @@ const crearCurso = async (req, res) => {
         });
 
     } catch (error) {
-        console.error(error);
         next(error);
     }
 };

--- a/src/controllers/cursoController.js
+++ b/src/controllers/cursoController.js
@@ -12,13 +12,12 @@ const getAll = async (req, res, next) => {
             cursos
         });
     } catch (error) {
-        /* res.status(500).json({ error: error.message });*/
-        next(error);
+       next(error);
     }
 };
 
 /** GET /cursos/:id */
-const getById = async (req, resl, next) => {
+const getById = async (req, res, next) => {
     try {
         const curso = await Curso.findByPk(req.params.id, {
             include: [
@@ -27,26 +26,23 @@ const getById = async (req, resl, next) => {
                 Alumno
             ],
         });
-        /* if (!curso)
-            return res.redirect("/cursos");*/
         if (!curso) {
             req.session.flash = {
-            type: "error",
-            title: "No trobat",
-            message: "El curs no existeix.",
-        };
-        return res.redirect("/cursos");
-    }
+                type: "error",
+                title: "No trobat",
+                message: "El curs no existeix.",
+                };
+                return res.redirect("/cursos");
+            }
 
-        res.render("curso-detalle", {
-            titulo: "Busqueda de cursos por ID",
-            usuario: req.session.usuario,
-            css: "cursos.css",
-            curso
-        });
+            res.render("curso-detalle", {
+                titulo: "Busqueda de cursos por ID",
+                usuario: req.session.usuario,
+                css: "cursos.css",
+                curso
+                });
 
-    } catch (error) {
-        /* res.status(500).json({ error: error.message }); */
+        } catch (error) {
         next(error);
     }
 };
@@ -59,8 +55,7 @@ const renderNuevoCurso = (req, res) => {
         css: "cursos.css",
         js: "cursos.js",
         paginaActual: "cursos",
-
-    });
+        });
 };
 
 /** Crear curso (POST) */
@@ -97,7 +92,7 @@ const crearCurso = async (req, res) => {
 
     } catch (error) {
         console.error(error);
-        res.status(500).json({ errores: ["Error al crear el curso"] });
+        next(error);
     }
 };
 

--- a/src/public/css/500.css
+++ b/src/public/css/500.css
@@ -1,0 +1,25 @@
+.error500 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80vh;
+  text-align: center;
+}
+
+.error500__content {
+  max-width: 500px;
+}
+
+.error500__title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.error500__text {
+  margin-bottom: 1.5rem;
+  color: #666;
+}
+
+.error500__button {
+  text-decoration: none;
+}

--- a/src/public/js/500.js
+++ b/src/public/js/500.js
@@ -1,0 +1,12 @@
+const backButton = document.querySelector("#backButton");
+
+if (backButton) {
+    backButton.addEventListener("click", (event) => {
+        if (window.history.length > 1) {
+            event.preventDefault();
+            window.history.back();
+        } else {
+            window.location.href = "/";
+        }
+  });
+}

--- a/src/server.js
+++ b/src/server.js
@@ -60,6 +60,21 @@ server.use((req, res) => {
   });
 });
 
+// -------------------------------------------------------
+// HANDLER DE ERRORES
+// -------------------------------------------------------
+server.use((err, req, res, next) => {
+  console.error(err);
+  if (req.xhr || req.headers.accept?.includes("application/json")) {
+    return res.status(500).json({ error: "Error del servidor" });
+  }
+  res.status(500).render("500", {
+    titulo: "Error del servidor",
+    usuario: req.session?.usuario,
+    css: "500.css",
+    js: "500.js"
+  });
+});
 
 // -------------------------------------------------------
 // Arrancar

--- a/src/views/500.ejs
+++ b/src/views/500.ejs
@@ -1,0 +1,23 @@
+<!--<%- include("layout", { titulo }) %>
+
+ <div class="error-container">
+  <h1>Error del servidor</h1>
+  <p>Ha ocurrido un error inesperado.</p>
+  <a href="/dashboard">Volver al dashboard</a>
+</div> -->
+<section class="error500">
+  <div class="error500__content">
+    <h1 class="error500__title">Error del servidor</h1>
+    <p class="error500__text">Ha ocurrido un error inesperado.</p>
+
+    <% if (usuario) { %>
+      <a href="/dashboard" class="btn btn-primario error500__button">
+        Tornar al dashboard
+      </a>
+    <% } else { %>
+      <a href="/login" class="btn btn-primario error500__button">
+        Tornar
+      </a>
+    <% } %>
+  </div>
+</section>

--- a/src/views/500.ejs
+++ b/src/views/500.ejs
@@ -1,10 +1,3 @@
-<!--<%- include("layout", { titulo }) %>
-
- <div class="error-container">
-  <h1>Error del servidor</h1>
-  <p>Ha ocurrido un error inesperado.</p>
-  <a href="/dashboard">Volver al dashboard</a>
-</div> -->
 <section class="error500">
   <div class="error500__content">
     <h1 class="error500__title">Error del servidor</h1>


### PR DESCRIPTION
Complementar la gestión de errores tras la página 404 (https://github.com/CIFO-IFCD0111-2526/CIFO_CRM_project/issues/83) cubriendo dos casos que faltan:

    Errores 500 no controlados — actualmente Express responde con stacktrace HTML feo si algo lanza fuera de un try/catch.
    404 de recurso — cuando se busca un alumno/curso/profesor por id y no existe, el controller hace res.redirect("/alumnos") silencioso. El usuario no entiende por qué le han devuelto al listado.

Close #84 