### PR TITLE
feat: CRUD Profesor - crear

### DIFF
--- a/src/controllers/profesorController.js
+++ b/src/controllers/profesorController.js
@@ -28,4 +28,75 @@ const listarProfesores = async (req, res) => {
     }
 };
 
-module.exports = { listarProfesores };
+/** GET /profesores/nuevo — formulari alta */
+const mostrarFormCrear = (req, res) => {
+    res.render("profesor-form", {
+        titulo: "Nou professor",
+        usuario: req.session.usuario,
+        css: "profesores.css",
+        js: "profesores.js",
+        paginaActual: "profesores",
+        styles: '<link rel="stylesheet" href="/css/forms.css">',
+    });
+};
+
+/** POST /profesores — crear professor */
+const crearProfesor = async (req, res) => {
+    const { nombre, apellidos, telefono, email } = req.body;
+
+    if (!nombre || !apellidos || !email) {
+        return res.status(400).json({ ok: false, error: "Nom, cognoms i email són obligatoris." });
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        return res.status(400).json({ ok: false, error: "Format d'email no vàlid." });
+    }
+
+    try {
+        const existe = await Profesor.findOne({ where: { email } });
+        if (existe) {
+            return res.status(400).json({ ok: false, error: "Ja existeix un professor amb aquest email." });
+        }
+
+        const profesor = await Profesor.create({
+            nombre,
+            apellidos,
+            telefono: telefono || null,
+            email,
+        });
+
+        return res.status(201).json({ ok: true, redirect: `/profesores/${profesor.id}` });
+    } catch (error) {
+        if (error.name === "SequelizeValidationError") {
+            return res.status(400).json({ ok: false, error: error.errors[0].message });
+        }
+        console.error(error);
+        return res.status(500).json({ ok: false, error: "Error del servidor." });
+    }
+};
+
+/** GET /profesores/:id — detall professor */
+const getById = async (req, res) => {
+    try {
+        const profesor = await Profesor.findByPk(req.params.id, {
+            include: [{ model: Curso, attributes: ["id", "codigo", "nombre"] }],
+        });
+
+        if (!profesor) {
+            return res.redirect("/profesores");
+        }
+
+        res.render("profesor-detalle", {
+            titulo: `${profesor.nombre} ${profesor.apellidos}`,
+            usuario: req.session.usuario,
+            css: "profesores.css",
+            js: "profesores.js",
+            paginaActual: "profesores",
+            profesor,
+        });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+};
+
+module.exports = { listarProfesores, mostrarFormCrear, crearProfesor, getById };

--- a/src/models/Profesor.js
+++ b/src/models/Profesor.js
@@ -27,6 +27,7 @@ const Profesor = sequelize.define(
       allowNull: false,
       validate: {
         notEmpty: { msg: "Los apellidos no pueden estar vacíos" },
+        len: { args: [2, 150], msg: "Els cognoms han de tenir entre 2 i 150 caràcters" },
       },
     },
     telefono: {

--- a/src/public/js/profesores.js
+++ b/src/public/js/profesores.js
@@ -1,0 +1,89 @@
+const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const setError = (input) => input.classList.add("error");
+const clearError = (input) => input.classList.remove("error");
+
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.querySelector("#profesorForm");
+  if (!form) return;
+
+  const profesorMsg = document.querySelector("#profesorMsg");
+  const nombre = document.querySelector("#profesorNombre");
+  const apellidos = document.querySelector("#profesorApellidos");
+  const telefono = document.querySelector("#profesorTelefono");
+  const email = document.querySelector("#profesorEmail");
+
+  const showMsg = (html, isError = true) => {
+    profesorMsg.innerHTML = html;
+    profesorMsg.style.display = "block";
+    profesorMsg.classList.toggle("error-msg", isError);
+  };
+
+  const clearMsg = () => {
+    profesorMsg.innerHTML = "";
+    profesorMsg.style.display = "none";
+    profesorMsg.classList.remove("error-msg");
+  };
+
+  if (sessionStorage.getItem("professorCreat")) {
+    sessionStorage.removeItem("professorCreat");
+    window.showModal?.({
+      type: "success",
+      title: "Professor creat",
+      message: "Has creat el professor correctament.",
+    });
+  }
+
+  [nombre, apellidos, email].forEach((input) => {
+    input.addEventListener("input", () => clearError(input));
+  });
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg();
+
+    const formData = new FormData(form);
+    const data = Object.fromEntries(formData.entries());
+
+    const errors = [];
+
+    if (!data.nombre) {
+      errors.push("El nom és obligatori.");
+      setError(nombre);
+    }
+
+    if (!data.apellidos) {
+      errors.push("Els cognoms són obligatoris.");
+      setError(apellidos);
+    }
+
+    if (!data.email) {
+      errors.push("L'email és obligatori.");
+      setError(email);
+    } else if (!isValidEmail(data.email)) {
+      errors.push("El format de l'email no és vàlid.");
+      setError(email);
+    }
+
+    if (errors.length > 0) {
+      showMsg(errors.join("<br>"));
+      return;
+    }
+
+    const res = await fetch("/profesores", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    const json = await res.json();
+
+    if (!json.ok) {
+      showMsg(json.error);
+      return;
+    }
+
+    sessionStorage.setItem("professorCreat", "true");
+    window.location.href = json.redirect;
+  });
+});

--- a/src/routes/profesorRoutes.js
+++ b/src/routes/profesorRoutes.js
@@ -8,7 +8,10 @@ const router = express.Router();
 const profesorController = require("../controllers/profesorController");
 const { authPage } = require("../middlewares/auth");
 
+router.get("/nuevo", authPage, profesorController.mostrarFormCrear);
 router.get("/", authPage, profesorController.listarProfesores);
+router.post("/", authPage, profesorController.crearProfesor);
+router.get("/:id", authPage, profesorController.getById);
 
 module.exports = router;
 

--- a/src/views/profesor-detalle.ejs
+++ b/src/views/profesor-detalle.ejs
@@ -1,0 +1,51 @@
+<div class="page-header">
+  <div>
+    <a href="/profesores" class="back-link">
+      <i class="fa-solid fa-arrow-left"></i> Tornar al llistat
+    </a>
+    <h1 class="page-title">
+      <%= profesor.nombre %> <%= profesor.apellidos %>
+    </h1>
+  </div>
+  <div class="acciones">
+    <a href="/profesores/<%= profesor.id %>/editar" class="btn btn-secundario">Editar</a>
+    <button type="button" class="btn btn-danger btn-eliminar" data-id="<%= profesor.id %>">Eliminar</button>
+  </div>
+</div>
+
+<div class="detalle-grid">
+
+  <section class="detalle-card">
+    <h2 class="detalle-card-title">Dades de contacte</h2>
+    <dl class="detalle-list">
+
+      <div class="detalle-item">
+        <dt>Email</dt>
+        <dd><%= profesor.email %></dd>
+      </div>
+
+      <div class="detalle-item">
+        <dt>Telèfon</dt>
+        <dd><%= profesor.telefono || '—' %></dd>
+      </div>
+
+    </dl>
+  </section>
+
+  <section class="detalle-card detalle-full">
+    <h2 class="detalle-card-title">Cursos que imparteix</h2>
+    <% if (profesor.Cursos && profesor.Cursos.length > 0) { %>
+      <ul class="detalle-cursos">
+        <% profesor.Cursos.forEach(curso => { %>
+          <li>
+            <span class="curso-codigo"><%= curso.codigo %></span>
+            <span class="curso-nombre"><%= curso.nombre %></span>
+          </li>
+        <% }) %>
+      </ul>
+    <% } else { %>
+      <p class="detalle-empty">No imparteix cap curs.</p>
+    <% } %>
+  </section>
+
+</div>

--- a/src/views/profesor-form.ejs
+++ b/src/views/profesor-form.ejs
@@ -1,0 +1,42 @@
+<div class="form-container">
+  <div class="form-card">
+    <h1 class="form-title">Nou professor</h1>
+    <p class="form-subtitle">Introdueix les dades del nou professor</p>
+
+    <form id="profesorForm" class="form-grid" novalidate>
+
+      <div class="form-group">
+        <label>
+          Nom
+          <input type="text" id="profesorNombre" name="nombre" placeholder="Nom" required />
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label>
+          Cognoms
+          <input type="text" id="profesorApellidos" name="apellidos" placeholder="Cognoms" required />
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label>
+          Telèfon
+          <input type="tel" id="profesorTelefono" name="telefono" placeholder="Telèfon" />
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label>
+          Email
+          <input type="email" id="profesorEmail" name="email" placeholder="professor@exemple.com" required />
+        </label>
+      </div>
+
+      <div id="profesorMsg" class="form-msg form-full" aria-live="polite"></div>
+
+      <button type="submit" class="btn btn-primario btn-block form-full">Crear professor</button>
+
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
closes #67

Implementado el formulario de alta de profesores y el POST para crearlos.
- GET /profesores/nuevo → profesor-form.ejs
- POST /profesores → valida y crea el profesor, redirige a /profesores/:id
- GET /profesores/:id → vista de detalle (necesario para el redirect)
- Validación frontend y backend (nombre, apellidos, email obligatorios; formato email; teléfono via Sequelize)
- Añadida validación de longitud mínima a apellidos en Profesor.js