### PR TITLE
fix/errores de validacion devueltos como 500 en lugar de 400

### DIFF
--- a/src/controllers/alumnoController.js
+++ b/src/controllers/alumnoController.js
@@ -1,6 +1,6 @@
 const { Op } = require("sequelize");
 const { Alumno, Curso } = require("../models");
-
+const { handleControllerError } = require("../middlewares/errorHandler");
 //GET /alumnos
 
 const getAll = async (req, res, next) => {
@@ -16,7 +16,7 @@ const getAll = async (req, res, next) => {
             alumnos
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -63,15 +63,15 @@ const newAlumno = async (req, res, next) => {
         });
 
         req.session.flash = {
-          type: "success",
-          title: "Alumne creat",
-          message: `L'alumne ${nuevoAlumno.nombre} ${nuevoAlumno.apellidos} s'ha creat correctament.`,
+            type: "success",
+            title: "Alumne creat",
+            message: `L'alumne ${nuevoAlumno.nombre} ${nuevoAlumno.apellidos} s'ha creat correctament.`,
         };
 
         return res.status(200).json({ ok: true, redirect: "/alumnos" });
 
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -100,7 +100,7 @@ const getById = async (req, res, next) => {
             alumno
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -113,21 +113,21 @@ const removeAlumno = async (req, res, next) => {
             message: "Alumno no trobat"
         });
         await alumno.destroy();
-        
+
         req.session.flash = {
             type: "success",
             title: "Alumne eliminat",
             message: `L'alumne: ${alumno.nombre} ${alumno.apellidos} s'ha eliminat correctament.`,
             keepModal: true,
         };
-        
+
         return res.json({
             ok: true,
             /*message: "Alumne eliminat correctament",*/
             redirect: "/alumnos"
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -166,7 +166,7 @@ const buscarAlumno = async (req, res, next) => {
         return res.json(alumnos);
 
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -226,7 +226,7 @@ const updateAlumno = async (req, res, next) => {
         return res.json({ ok: true, redirect: `/alumnos/${req.params.id}` });
 
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 

--- a/src/controllers/alumnoController.js
+++ b/src/controllers/alumnoController.js
@@ -16,7 +16,7 @@ const getAll = async (req, res, next) => {
             alumnos
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -71,7 +71,7 @@ const newAlumno = async (req, res, next) => {
         return res.status(200).json({ ok: true, redirect: "/alumnos" });
 
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -100,7 +100,7 @@ const getById = async (req, res, next) => {
             alumno
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -127,7 +127,7 @@ const removeAlumno = async (req, res, next) => {
             redirect: "/alumnos"
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -166,7 +166,7 @@ const buscarAlumno = async (req, res, next) => {
         return res.json(alumnos);
 
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -226,7 +226,7 @@ const updateAlumno = async (req, res, next) => {
         return res.json({ ok: true, redirect: `/alumnos/${req.params.id}` });
 
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -28,7 +28,7 @@ const forgotPasswordForm = (req, res) => {
 
 // POST /login
 
-const login = async (req, res) => {
+const login = async (req, res, next) => {
   const { loginEmail, loginPassword, loginRemember } = req.body;
 
   try {
@@ -67,7 +67,7 @@ const login = async (req, res) => {
     return res.status(200).json({ ok: true, redirect: "/dashboard" });
 
   } catch (error) {
-    return handleControllerError(error, res);
+    return handleControllerError(error, res, next);
   }
 };
 
@@ -84,7 +84,7 @@ const registerForm = async (req, res) => {
 
 //Procesar el registro de un nuevo usuario, validando que el email no exista, hasheando la contraseña y guardando el nuevo usuario en la base de datos.
 // POST /register
-const register = async (req, res) => {
+const register = async (req, res, next) => {
   const { nombre, apellidos, email, password } = req.body;
 
   // Validación básica
@@ -138,7 +138,7 @@ const register = async (req, res) => {
     return res.status(200).json({ ok: true, redirect: "/dashboard" });
 
   } catch (error) {
-    return handleControllerError(error, res);
+    return handleControllerError(error, res, next);
   }
 };
 
@@ -174,7 +174,7 @@ function generaContrasenaAleatoria(length = 10) {
 
 // POST /forgot-password
 
-const forgotPassword = async (req, res) => {
+const forgotPassword = async (req, res, next) => {
   const { email } = req.body;
 
   // Validación básica
@@ -229,7 +229,7 @@ const forgotPassword = async (req, res) => {
 
     return res.status(200).json({ ok: true, redirect: "/login" });
   } catch (error) {
-    return handleControllerError(error, res);
+    return handleControllerError(error, res, next);
   }
 };
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,6 +1,7 @@
 const { Usuario } = require("../models");
 const bcrypt = require("bcrypt");
 const { sendMail } = require("../config/mailer.js");
+const { handleControllerError } = require("../middlewares/errorHandler.js");
 
 // GET /login
 
@@ -66,7 +67,7 @@ const login = async (req, res) => {
     return res.status(200).json({ ok: true, redirect: "/dashboard" });
 
   } catch (error) {
-    res.status(500).json({ error: "Error del servidor." });
+    return handleControllerError(error, res);
   }
 };
 
@@ -111,9 +112,9 @@ const register = async (req, res) => {
       password: hashedPassword,
       nivel_acceso: "editor",
       activo: true,
-    });    
+    });
 
-// AÑADIR CREACION DE SESSION PARA PODER IR DIRECTO A DASHBOARD ////////////////////////////////
+    // AÑADIR CREACION DE SESSION PARA PODER IR DIRECTO A DASHBOARD ////////////////////////////////
     const userLogin = await Usuario.findOne({
       where: { email: email, activo: true },
     });
@@ -127,18 +128,17 @@ const register = async (req, res) => {
     };
     req.session.cookie.maxAge = 60 * 60 * 1000;  //  60 minutos per defecte, en registre no es guarda el ""recordar sessió""
     // req.session.flash = ""; //  añadir para la logica que muestra el modal("flash") de "Jose"
-    
+
     req.session.flash = {
       type: "success",
       title: "Compte creat.",
       message: `Benvingut, ${userLogin.nombre} ${userLogin.apellidos}.`,
     };
-///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
     return res.status(200).json({ ok: true, redirect: "/dashboard" });
 
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Error del servidor." });
+    return handleControllerError(error, res);
   }
 };
 
@@ -229,9 +229,8 @@ const forgotPassword = async (req, res) => {
 
     return res.status(200).json({ ok: true, redirect: "/login" });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Error del servidor." });
+    return handleControllerError(error, res);
   }
 };
 
-module.exports = { loginForm, login, registerForm, register, logout , forgotPassword ,  forgotPasswordForm  };
+module.exports = { loginForm, login, registerForm, register, logout, forgotPassword, forgotPasswordForm };

--- a/src/controllers/cursoController.js
+++ b/src/controllers/cursoController.js
@@ -12,7 +12,7 @@ const getAll = async (req, res, next) => {
             cursos
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -43,7 +43,7 @@ const getById = async (req, res, next) => {
             curso
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -97,7 +97,7 @@ const crearCurso = async (req, res, next) => {
         });
 
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -124,7 +124,7 @@ const eliminarCurso = async (req, res, next) => {
             redirect: "/cursos"
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 

--- a/src/controllers/cursoController.js
+++ b/src/controllers/cursoController.js
@@ -1,5 +1,5 @@
 const { Curso, Alumno, Uf, Profesor } = require("../models");
-
+const { handleControllerError } = require("../middlewares/errorHandler");
 /** GET /cursos */
 const getAll = async (req, res, next) => {
     try {
@@ -12,7 +12,7 @@ const getAll = async (req, res, next) => {
             cursos
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -43,7 +43,7 @@ const getById = async (req, res, next) => {
             curso
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -97,7 +97,7 @@ const crearCurso = async (req, res, next) => {
         });
 
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 
@@ -124,7 +124,7 @@ const eliminarCurso = async (req, res, next) => {
             redirect: "/cursos"
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 

--- a/src/controllers/profesorController.js
+++ b/src/controllers/profesorController.js
@@ -3,6 +3,7 @@
 // -------------------------------------------------------
 
 const { Profesor, Curso } = require("../models");
+const { handleControllerError } = require("../middlewares/errorHandler");
 
 /** GET /profesores — listar todos */
 const listarProfesores = async (req, res) => {
@@ -24,7 +25,7 @@ const listarProfesores = async (req, res) => {
             profesores,
         });
     } catch (error) {
-        res.status(500).send("Error al cargar profesores: " + error.message);
+        return handleControllerError(error, res);
     }
 };
 
@@ -67,11 +68,7 @@ const crearProfesor = async (req, res) => {
 
         return res.status(201).json({ ok: true, redirect: `/profesores/${profesor.id}` });
     } catch (error) {
-        if (error.name === "SequelizeValidationError") {
-            return res.status(400).json({ ok: false, error: error.errors[0].message });
-        }
-        console.error(error);
-        return res.status(500).json({ ok: false, error: "Error del servidor." });
+        return handleControllerError(error, res);
     }
 };
 
@@ -95,7 +92,7 @@ const getById = async (req, res) => {
             profesor,
         });
     } catch (error) {
-        res.status(500).json({ error: error.message });
+        return handleControllerError(error, res);
     }
 };
 

--- a/src/controllers/profesorController.js
+++ b/src/controllers/profesorController.js
@@ -6,7 +6,7 @@ const { Profesor, Curso } = require("../models");
 const { handleControllerError } = require("../middlewares/errorHandler");
 
 /** GET /profesores — listar todos */
-const listarProfesores = async (req, res) => {
+const listarProfesores = async (req, res, next) => {
     try {
         const profesores = await Profesor.findAll({
             include: [{
@@ -25,7 +25,7 @@ const listarProfesores = async (req, res) => {
             profesores,
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
@@ -42,7 +42,7 @@ const mostrarFormCrear = (req, res) => {
 };
 
 /** POST /profesores — crear professor */
-const crearProfesor = async (req, res) => {
+const crearProfesor = async (req, res, next) => {
     const { nombre, apellidos, telefono, email } = req.body;
 
     if (!nombre || !apellidos || !email) {
@@ -68,12 +68,12 @@ const crearProfesor = async (req, res) => {
 
         return res.status(201).json({ ok: true, redirect: `/profesores/${profesor.id}` });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 
 /** GET /profesores/:id — detall professor */
-const getById = async (req, res) => {
+const getById = async (req, res, next) => {
     try {
         const profesor = await Profesor.findByPk(req.params.id, {
             include: [{ model: Curso, attributes: ["id", "codigo", "nombre"] }],
@@ -92,7 +92,7 @@ const getById = async (req, res) => {
             profesor,
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 

--- a/src/controllers/ufController.js
+++ b/src/controllers/ufController.js
@@ -1,5 +1,5 @@
 const { Uf, Curso } = require("../models");
-
+const { handleControllerError } = require("../middlewares/errorHandler");
 // GET /ufs
 const getAll = async (req, res) => {
     try {
@@ -16,7 +16,7 @@ const getAll = async (req, res) => {
             ufs,
         });
     } catch (error) {
-        res.status(500).json({ error: error.message });
+        return handleControllerError(error, res);
     }
 };
 // GET /ufs/:id
@@ -45,7 +45,7 @@ const getById = async (req, res, next) => {
             uf
         });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 // GET /ufs/nuevo
@@ -93,7 +93,7 @@ const postCrear = async (req, res) => {
             redirect: `/ufs/${nuevaUF.id}`,
         });
     } catch (error) {
-        return res.status(500).json({ ok: false, error: error.message });
+        return handleControllerError(error, res);
     }
 };
 //DELETE/ufs/:id
@@ -112,7 +112,7 @@ const removeUf = async (req, res, next) => {
         };
         return res.status(200).json({ ok: true, redirect: "/ufs" });
     } catch (error) {
-        next(error);
+        return handleControllerError(error, res);
     }
 };
 

--- a/src/controllers/ufController.js
+++ b/src/controllers/ufController.js
@@ -1,7 +1,7 @@
 const { Uf, Curso } = require("../models");
 const { handleControllerError } = require("../middlewares/errorHandler");
 // GET /ufs
-const getAll = async (req, res) => {
+const getAll = async (req, res, next) => {
     try {
         const ufs = await Uf.findAll({
             include: [{ model: Curso, attributes: ["id", "codigo", "nombre"] }],
@@ -16,7 +16,7 @@ const getAll = async (req, res) => {
             ufs,
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 // GET /ufs/:id
@@ -45,7 +45,7 @@ const getById = async (req, res, next) => {
             uf
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 // GET /ufs/nuevo
@@ -62,7 +62,7 @@ const getNuevo = (req, res) => {
 };
 
 // POST /ufs
-const postCrear = async (req, res) => {
+const postCrear = async (req, res, next) => {
     const { codigo, nombre, horas } = req.body;
     const errores = {};
 
@@ -93,7 +93,7 @@ const postCrear = async (req, res) => {
             redirect: `/ufs/${nuevaUF.id}`,
         });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 //DELETE/ufs/:id
@@ -112,7 +112,7 @@ const removeUf = async (req, res, next) => {
         };
         return res.status(200).json({ ok: true, redirect: "/ufs" });
     } catch (error) {
-        return handleControllerError(error, res);
+        return handleControllerError(error, res, next);
     }
 };
 

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,6 +1,9 @@
 const { ValidationError, UniqueConstraintError } = require("sequelize");
 
-function handleControllerError(error, res, fallbackMessage = "Error del servidor.") {
+// Errores de validación de Sequelize → 400 con detalle por campo.
+// Cualquier otro error se delega a `next` para que el handler global
+// (server.js) decida si renderizar 500.ejs o devolver JSON 500.
+function handleControllerError(error, res, next) {
   if (error instanceof ValidationError || error instanceof UniqueConstraintError) {
     const errores = {};
     error.errors?.forEach((e) => {
@@ -8,8 +11,7 @@ function handleControllerError(error, res, fallbackMessage = "Error del servidor
     });
     return res.status(400).json({ ok: false, errores });
   }
-  console.error(error);
-  return res.status(500).json({ ok: false, error: fallbackMessage });
+  return next(error);
 }
 
 module.exports = { handleControllerError };

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,0 +1,15 @@
+const { ValidationError, UniqueConstraintError } = require("sequelize");
+
+function handleControllerError(error, res, fallbackMessage = "Error del servidor.") {
+  if (error instanceof ValidationError || error instanceof UniqueConstraintError) {
+    const errores = {};
+    error.errors?.forEach((e) => {
+      errores[e.path] = e.message;
+    });
+    return res.status(400).json({ ok: false, errores });
+  }
+  console.error(error);
+  return res.status(500).json({ ok: false, error: fallbackMessage });
+}
+
+module.exports = { handleControllerError };


### PR DESCRIPTION
Creacion de un helper que distinga SequelizeValidationError y SequelizeUniqueConstraintError del resto. 
Sustituir:
  res.status(500).json({ error: "Error del servidor.";
Por:
  return handleControllerError(error, res);
en cada controller
closes #95 