### PR TITLE
feat: buscador de professors amb autocompletar

### DIFF
--- a/src/controllers/profesorController.js
+++ b/src/controllers/profesorController.js
@@ -2,6 +2,7 @@
 // Controller: Profesores (renderiza vistas)
 // -------------------------------------------------------
 
+const { Op } = require("sequelize");
 const { Profesor, Curso } = require("../models");
 const { handleControllerError } = require("../middlewares/errorHandler");
 
@@ -157,4 +158,36 @@ const deleteProfesor = async (req, res, next) => {
     }
 };
 
-module.exports = { getAll, renderNewProfesor, createProfesor, getById, getEditForm, updateProfesor, deleteProfesor };
+const searchProfesor = async (req, res, next) => {
+    const q = (req.query.q || "").trim();
+
+    // Si hi ha menys de 2 caràcters → retornem array buit
+    if (q.length < 2) {
+        return res.json([]);
+    }
+
+    // Construïm el filtre de cerca
+    const where = {
+        [Op.or]: [
+            { nombre: { [Op.like]: `%${q}%` } },
+            { apellidos: { [Op.like]: `%${q}%` } },
+            { email: { [Op.like]: `%${q}%` } }
+        ]
+    };
+
+    try {
+        const profesores = await Profesor.findAll({
+            where,
+            limit: 10,
+            order: [["apellidos", "ASC"]],
+            attributes: ["id", "nombre", "apellidos", "email"]
+        });
+
+        return res.json(profesores);
+
+    } catch (error) {
+        return handleControllerError(error, res, next);
+    }
+};
+
+module.exports = { getAll, renderNewProfesor, createProfesor, getById, getEditForm, updateProfesor, deleteProfesor, searchProfesor };

--- a/src/public/js/profesores.js
+++ b/src/public/js/profesores.js
@@ -121,3 +121,70 @@ document.addEventListener("click", async (e) => {
     });
   }
 });
+
+// Buscador d'profesores amb autocompletar
+document.addEventListener("DOMContentLoaded", () => {
+  const input = document.getElementById("busquedaProfesor");
+  const dropdown = document.getElementById("dropdownResultados");
+  if (input && dropdown) initBuscador(input, dropdown);
+});
+
+function initBuscador(input, dropdown) {
+  let debounceTimer = null;
+
+  input.addEventListener("input", () => {
+    const query = input.value.trim();
+    if (query.length < 2) {
+      cerrarDropdown();
+      return;
+    }
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => searchProfesores(query), 250);
+  });
+
+  async function searchProfesores(query) {
+    try {
+      const res = await fetch(`/profesores/buscar?q=${encodeURIComponent(query)}`, {
+        credentials: "include",
+      });
+      const data = await res.json();
+      renderResultados(data);
+    } catch (error) {
+      console.error("Error en cerca:", error);
+    }
+  }
+
+  function renderResultados(profesores) {
+    dropdown.innerHTML = "";
+    if (!profesores.length) {
+      dropdown.innerHTML = `<div class="item empty">Sense resultats</div>`;
+    } else {
+      profesores.forEach((profesor) => {
+        const item = document.createElement("div");
+        item.classList.add("item");
+        item.textContent = `${profesor.apellidos}, ${profesor.nombre} — ${profesor.email}`;
+        item.addEventListener("click", () => {
+          window.location.href = `/profesores/${profesor.id}`;
+        });
+        dropdown.appendChild(item);
+      });
+    }
+    dropdown.classList.remove("hidden");
+  }
+
+  function cerrarDropdown() {
+    dropdown.classList.add("hidden");
+    dropdown.innerHTML = "";
+  }
+
+  input.addEventListener("blur", () => {
+    setTimeout(cerrarDropdown, 150);
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      cerrarDropdown();
+      input.blur();
+    }
+  });
+}

--- a/src/routes/profesorRoutes.js
+++ b/src/routes/profesorRoutes.js
@@ -12,6 +12,9 @@ const { Profesor, Curso } = require("../models");
 
 router.use(authPage);
 
+// Ruta para buscar profesores por nombre o apellido
+router.get("/buscar", profesorController.searchProfesor);
+
 router.get("/nuevo", profesorController.renderNewProfesor);
 router.get("/", profesorController.getAll);
 router.post("/", profesorController.createProfesor);

--- a/src/views/profesores.ejs
+++ b/src/views/profesores.ejs
@@ -3,9 +3,6 @@
     <h1 class="page-title">Professors</h1>
     <p class="page-subtitle">Llistat de professors registrats al centre</p>
   </div>
-  <a href="/profesores/nuevo" class="btn btn-primario">Nou professor</a>
-</div>
-
 <div class="buscador-wrapper">
   <div class="buscador-alumnos">
     <input
@@ -16,6 +13,8 @@
     />
   </div>
   <div id="dropdownResultados" class="dropdown hidden"></div>
+</div>
+  <a href="/profesores/nuevo" class="btn btn-primario">Nou professor</a>
 </div>
 
 <% if (profesores && profesores.length > 0) { %>

--- a/src/views/profesores.ejs
+++ b/src/views/profesores.ejs
@@ -3,17 +3,17 @@
     <h1 class="page-title">Professors</h1>
     <p class="page-subtitle">Llistat de professors registrats al centre</p>
   </div>
-<div class="buscador-wrapper">
-  <div class="buscador-alumnos">
-    <input
-      type="text"
-      id="busquedaProfesor"
-      placeholder="Buscar professor..."
-      autocomplete="off"
-    />
+  <div class="buscador-wrapper">
+    <div class="buscador-alumnos">
+      <input
+        type="text"
+        id="busquedaProfesor"
+        placeholder="Buscar professor..."
+        autocomplete="off"
+      />
+    </div>
+    <div id="dropdownResultados" class="dropdown hidden"></div>
   </div>
-  <div id="dropdownResultados" class="dropdown hidden"></div>
-</div>
   <a href="/profesores/nuevo" class="btn btn-primario">Nou professor</a>
 </div>
 
@@ -56,16 +56,9 @@
                   Veure
                 </a> -->
 
-                <a href="/profesores/<%= profesor.id %>/editar" class="btn btn-secundario btn-sm">
+                <a href="/profesores/<%= profesor.id %>" class="btn btn-secundario btn-sm">
                   Editar
                 </a>
-
-                <button
-                  type="button"
-                  class="btn btn-danger btn-sm btn-eliminar"
-                  data-id="<%= profesor.id %>">
-                  Eliminar
-                </button>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Implementa el buscador de profesores con autocompletar

- Añade el endpoint `GET /profesores/buscar`
- Busca por `nombre`, `apellidos` y `email`
- Muestra resultados en dropdown con autocompletado
- Redirige al detalle del profesor al hacer click

closes #116
